### PR TITLE
design tags changed to standard, and spider fixed all

### DIFF
--- a/knows/knows/spiders/shijueSpider.py
+++ b/knows/knows/spiders/shijueSpider.py
@@ -48,6 +48,6 @@ class shijueSpider(CrawlSpider):
 
         item['content'] = sel.xpath('//div[@class="article-body mt-20"]')[0].extract()
 
-        item['tag'] = 'Design'
+        item['tag'] = 'viewdesign'
 
         return item

--- a/knows/knows/spiders/uisdcSpider.py
+++ b/knows/knows/spiders/uisdcSpider.py
@@ -48,6 +48,6 @@ class uisdcSpider(CrawlSpider):
             real_content = real_content + line
         item['content'] = real_content
 
-        item['tag'] = 'Design'
+        item['tag'] = 'uidesign'
 
         return item


### PR DESCRIPTION
1.看了log，出现问题的爬虫除了昨天发现的还有woshipm，这个bug昨天修复了，应该是变量没初始化的问题。
2.design的tag昨天改的名称不标准，现在改成标准的英文了
